### PR TITLE
Added Gecko Id to manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -35,5 +35,10 @@
     "48": "assets/icons/48.png",
     "128": "assets/icons/128.png"
   },
+  "applications": {
+    "gecko": {
+    "id": "blocktube@amitbl.org"
+    }
+  },
   "homepage_url": "https://github.com/amitbl/blocktube"
 }


### PR DESCRIPTION
Some Firefox forks rely on strict ID tags since firefox changes them on restart some browsers that focus on security and privacy ex; Icecat and Android still require this to be present and will refuse to install without them present in the manifest. This will force min versioning on updates "strict_min_version". And cause warnings in chrome. That said they both can be fixed using the makefile.

The Firefox official docs regarding this can be found here; [Firefox Docs](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/WebExtensions_and_the_Add-on_ID#When_do_you_need_an_add-on_ID)