### PR TITLE
Fix some code typos

### DIFF
--- a/src/scripts/inject.js
+++ b/src/scripts/inject.js
@@ -510,7 +510,7 @@
   // !! Utils
 
   function postMessage(type, data) {
-    window.postMessage({ from: 'BLOCKTUBE_PAGE', type, data }, document.locaion.origin);
+    window.postMessage({ from: 'BLOCKTUBE_PAGE', type, data }, document.location.origin);
   }
 
   function getObjectByPath(obj, path, def = undefined) {
@@ -794,7 +794,7 @@
     window.dispatchEvent(new Event('blockTubeReady'));
   }
 
-  function storageRecieved(data) {
+  function storageReceived(data) {
     if (data === undefined) return;
     transformToRegExp(data);
     if (data.options.trending) blockTrending(data);
@@ -817,7 +817,7 @@
 
     switch (event.data.type) {
       case 'storageData': {
-        storageRecieved(event.data.data);
+        storageReceived(event.data.data);
         break;
       }
       default:


### PR DESCRIPTION
Fix typo in function name, and fix a document.locaion to read
document.location.

Note: I haven't even tested this, so please test and make sure it works fine before merging! Also, I wonder what consequences fixing the typo in document.location will have 😅 I just installed the extension now, and discovered those problems while reviewing the code before installing 😄