### PR TITLE
Make the status message more visible

### DIFF
--- a/src/ui/options.html
+++ b/src/ui/options.html
@@ -88,7 +88,7 @@
           <input type="button" id="export" value="Export" />
           <input type="button" id="import" value="Import" />
           <input type="file" id="myfile" accept="application/json" style="display:none" />
-          <div class="status-text" id="status_save"></div>
+          <span class="status-text" id="status_save"></span>
         </div>
       </form>
     </div>

--- a/src/ui/style.css
+++ b/src/ui/style.css
@@ -15,6 +15,7 @@ body {
 }
 
 .status-text {
+  margin: 1em;
   padding-top:5px;
   font-size: larger;
   font-weight:bold;


### PR DESCRIPTION
The status message used to appear under the buttons. This was a bit
of a problem because one would have to scroll down in order to see
the message, and those messages could be lost.

So, instead, place the status message besides the buttons, to make
sure they're both more visible, and close to where the user's eyes
probably are anyway after clicking on the Save button.