### PR TITLE
[DRAFT] Fix TrustedScript security issue on custom script `eval()`

### DIFF
--- a/src/scripts/inject.js
+++ b/src/scripts/inject.js
@@ -1411,6 +1411,15 @@
     // Enable JS filtering only if function has something in it
     if (storageData.options.enable_javascript && storageData.filterData.javascript) {
       try {
+        try {
+          if (window.trustedTypes && window.trustedTypes.createPolicy) {
+            window.trustedTypes.createPolicy('default', {
+              createHTML: string => string,
+              createScriptURL: string => string,
+              createScript: string => string,
+            });
+          }
+        } catch (e) {}
         jsFilter = window.eval(storageData.filterData.javascript);
         if (!(jsFilter instanceof Function)) {
           throw Error("Function not found");


### PR DESCRIPTION
Starting today, evaluation of the custom blocking rules script stopped working for me. The exception in the console is `This document requires 'TrustedScript' assignment.`.

This can be worked around by creating a trusted types policy. There is probably a better and more secure way to achieve this, so I'm marking this PR as draft. If I have more time available, I will look into this in more detail. For now, this small patch fixes the evaluation of custom blocking rules script.
