### PR TITLE
feat: Add block options to shorts menu (help wanted)

### DIFF
--- a/src/scripts/inject.js
+++ b/src/scripts/inject.js
@@ -1704,7 +1704,6 @@
         parentDom.setAttribute('is-dismissed', '');
       }
     } else {
-      // Video does not get hidden for Shorts
       document.getElementById('movie_player').stopVideo();
     }
     if (this.data.serviceEndpoint) {

--- a/src/scripts/inject.js
+++ b/src/scripts/inject.js
@@ -123,6 +123,8 @@
     'commentRenderer',
     'playlistPanelVideoRenderer',
     'playlistVideoRenderer',
+    // Desktop Shorts
+    'reelPlayerOverlayRenderer',
     // Mobile
     'reelItemRenderer',
     'slimVideoMetadataSectionRenderer',
@@ -1333,6 +1335,10 @@
     let hasVideo = false;
     if (has.call(obj[attr], 'videoActions')) {
       items = obj[attr].videoActions.menuRenderer.items;
+      hasChannel = true;
+      hasVideo = true;
+    } else if (has.call(obj[attr], 'menu')) {
+      items = obj[attr].menu.menuRenderer.items;
       hasChannel = true;
       hasVideo = true;
     } else if (has.call(obj[attr], 'actionMenu')) {

--- a/src/scripts/inject.js
+++ b/src/scripts/inject.js
@@ -1597,7 +1597,7 @@
     const shortsDom = eventSink.parentElement.parentElement.parentElement.parentElement.parentElement.parentElement
     const ytShortsData = getObjectByPath(eventSink, 'polymerController.__data');
     
-    // Set shortsDom as the last fallback, because eventSink itself exists, but child properties are undefined
+    // Set shortsDom as the last fallback, because eventSink itself exists, but child properties are undefined for Shorts
     const parentDom = eventSink?.parentComponent || eventSink.parentElement?.__dataHost?.hostElement || shortsDom;
     const parentData = parentDom?.data || ytShortsData.data;
 
@@ -1633,7 +1633,6 @@
 
       const ownerRenderer = document.getElementsByTagName('ytd-video-owner-renderer')[0];
       const owner = ownerRenderer.data || ownerRenderer.getCurrentData();
-      console.log("🚀 ~ menuOnTap ~ owner:", owner)
 
       const ownerUCID = owner.title.runs[0].navigationEndpoint.browseEndpoint.browseId;
       let playerUCID = player.videoDetails.channelId;
@@ -1705,6 +1704,7 @@
         parentDom.setAttribute('is-dismissed', '');
       }
     } else {
+      // Video does not get hidden for Shorts
       document.getElementById('movie_player').stopVideo();
     }
     if (this.data.serviceEndpoint) {


### PR DESCRIPTION
### Description 

Added block options to Shorts menu on Firefox (desktop) and Chrome.

### Known issues / Todo

I encountered a few problems and would appreciate some help.

- I tried to make it work on Firefox mobile, however the mobile variant of `reelPlayerOverlayRenderer` does not contain the `channelId`, `channelName`, `videoId` and `title` properties. The properties do exist on desktop.

- Block options do not exist in the menu when you scroll to the next Short

- Blocked videos and videos of blocked channels still play in your feed, even though `postMessage` function succeeded
 