### PR TITLE
Fix recommended right side hiding + improves member video badge

### DIFF
--- a/src/scripts/inject.js
+++ b/src/scripts/inject.js
@@ -353,7 +353,8 @@
         title: 'metadata.lockupMetadataViewModel.title.content',
         videoId: 'rendererContext.commandContext.onTap.innertubeCommand.watchEndpoint.videoId',
         channelId: 'metadata.lockupMetadataViewModel.image.decoratedAvatarViewModel.rendererContext.commandContext.onTap.innertubeCommand.browseEndpoint.browseId',
-        channelName: 'metadata.lockupMetadataViewModel.metadata.contentMetadataViewModel.metadataRows.metadataParts.text.content'
+        channelName: 'metadata.lockupMetadataViewModel.metadata.contentMetadataViewModel.metadataRows.metadataParts.text.content',
+        percentWatched: 'contentImage.thumbnailViewModel.overlays.thumbnailBottomOverlayViewModel.progressBar.thumbnailOverlayProgressBarViewModel.startPercent'
       },
 
       // Mobile top chips

--- a/src/scripts/inject.js
+++ b/src/scripts/inject.js
@@ -141,7 +141,8 @@
     'expandedShelfContentsRenderer',
     'comment',
     'commentThreadRenderer',
-    'reelShelfRenderer'
+    'reelShelfRenderer',
+    'richSectionRenderer'
   ];
 
   // those filter properties require RegExp checking
@@ -379,6 +380,9 @@
 
       // Empty for blocking short headers
       gridShelfViewModel: {
+      },
+
+      richSectionRenderer: {
       }
     },
     ytPlayer: {

--- a/src/scripts/inject.js
+++ b/src/scripts/inject.js
@@ -349,6 +349,13 @@
         channelBadges: 'ownerBadges',
       },
 
+      lockupViewModel: {
+        title: 'metadata.lockupMetadataViewModel.title.content',
+        videoId: 'rendererContext.commandContext.onTap.innertubeCommand.watchEndpoint.videoId',
+        channelId: 'metadata.lockupMetadataViewModel.image.decoratedAvatarViewModel.rendererContext.commandContext.onTap.innertubeCommand.browseEndpoint.browseId',
+        channelName: 'metadata.lockupMetadataViewModel.metadata.contentMetadataViewModel.metadataRows.metadataParts.text.content'
+      },
+
       // Mobile top chips
       chipCloudChipRenderer: {
         channelId: 'icon.iconType'
@@ -367,12 +374,7 @@
 
       tabRenderer: {
         channelId: 'endpoint.commandMetadata.webCommandMetadata.url'
-      },
-
-      lockupViewModel: {
-
       }
-
     },
     ytPlayer: {
       args: {

--- a/src/scripts/inject.js
+++ b/src/scripts/inject.js
@@ -528,6 +528,9 @@
             else if (br.metadataBadgeRenderer.style === "BADGE_STYLE_TYPE_LIVE_NOW") {
               badges.push("live");
             }
+            else if (br.metadataBadgeRenderer.style === "BADGE_STYLE_TYPE_MEMBERS_ONLY") { 
+              badges.push("members"); 
+            }
           });
           value = badges;
         }

--- a/src/scripts/inject.js
+++ b/src/scripts/inject.js
@@ -374,6 +374,10 @@
 
       tabRenderer: {
         channelId: 'endpoint.commandMetadata.webCommandMetadata.url'
+      },
+
+      // Empty for blocking short headers
+      gridShelfViewModel: {
       }
     },
     ytPlayer: {
@@ -559,7 +563,7 @@
       if (h === 'movieRenderer' || h === 'compactMovieRenderer') return true;
       if (h === 'videoRenderer' && !getObjectByPath(filteredObject, "shortBylineText.runs.navigationEndpoint.browseEndpoint") && filteredObject.longBylineText && filteredObject.badges) return true;
     }
-    if (storageData.options.shorts && (h === 'shortsLockupViewModel' || h === 'reelItemRenderer') ) return true;
+    if (storageData.options.shorts && (h === 'shortsLockupViewModel' || h === 'reelItemRenderer' || h === 'gridShelfViewModel') ) return true;
     if (storageData.options.mixes && (h === 'radioRenderer' || h === 'compactRadioRenderer')) return true;
     if (storageData.options.mixes && h === 'lockupViewModel') {
       let imgName = getObjectByPath(filteredObject, 'contentImage.collectionThumbnailViewModel.primaryThumbnail.thumbnailViewModel.overlays.thumbnailOverlayBadgeViewModel.thumbnailBadges.thumbnailBadgeViewModel.icon.sources.clientResource.imageName');


### PR DESCRIPTION
Fixed issue where videos on the right-hand side are not blocked.

Added badge for member videos. It should now be possible to use advanced blocking using:
```
if ( video.hasOwnProperty("badges") && video.badges.includes("members") ) { 
   return true; 
}
```
To block member videos.

Added check for "gridShelfViewModel" which seems to hold the short header, might be removing more than expected, but haven't noticed anything yet

Only tested on Chrome, needs to be verified for mobile and Firefox 