### PR TITLE
Fixed | Comments filtering on channel name and content

### DIFF
--- a/src/scripts/inject.js
+++ b/src/scripts/inject.js
@@ -438,8 +438,8 @@
     comments: {
       commentEntityPayload: {
         channelId: ['author.channelId'],
-        channelName: ['author.displayName'],
-        comment: ['properties.content.content']
+        channelName: ['microformat.microformatDataRenderer.videoDetails.comments[3].name', 'author.displayName'],
+        comment: ['microformat.microformatDataRenderer.videoDetails.comments[2]', 'properties.content.content']
       },
       commentThreadRenderer: {},
       commentViewModel: {},


### PR DESCRIPTION
With the changes from @somerandoname, I believe we can address some of the issues with the comment section filtering.
From what I can see, only the channel name and comment content are available. 