### PR TITLE
Fix mobile video pages redirecting to homepage

### DIFF
--- a/src/scripts/inject.js
+++ b/src/scripts/inject.js
@@ -848,6 +848,10 @@
   }
 
   function redirectToNextMobile() {
+    if (!currentBlock) {
+      return false;
+    }
+
     currentBlock = false;
 
     if (storageData.options.suggestions_only) {


### PR DESCRIPTION
## Summary

Fixes #629 - Video pages were redirecting to the homepage on all Android/mobile devices when BlockTube was active.

## Root Cause

The `redirectToNextMobile()` function is configured as a `customFunc` for `slimVideoMetadataSectionRenderer`, which appears on every mobile video page. The function was being called for ALL videos but wasn't checking whether a video was actually blocked before executing its redirect/delete logic.

This caused ALL videos on mobile (`m.youtube.com`) to either:
- Have their content deleted if autoplay was disabled
- Redirect to another video if autoplay was enabled

## Fix

Added a check at the start of `redirectToNextMobile()` to return early if `currentBlock` is false, ensuring the function only acts when a video has actually been blocked by the filter.

```javascript
function redirectToNextMobile() {
  if (!currentBlock) {
    return false;
  }
  // ... rest of redirect logic
}
```

This matches the pattern used elsewhere in the codebase where `currentBlock` is checked before executing redirect logic (e.g., line 1097 in `fetchFilter()`).

## Testing

- No syntax errors or diagnostics
- Minimal change (4 lines added)
- Preserves existing behavior for blocked videos
- Fixes the issue for non-blocked videos on mobile