### PR TITLE
Fixish Not blocking videos right hand side when watching video

### DIFF
--- a/src/scripts/seed.js
+++ b/src/scripts/seed.js
@@ -263,4 +263,26 @@
       customElementsRegistryDefine.call(window.customElements, name, constructor);
     }})
   }
+
+  // "Fix" which forcefully reloads the page when going to a watch video
+  // Needed because not all information is available when you click on a video on the home page
+  window.addEventListener('yt-navigate-finish', function(event) {
+    if (location.pathname === '/watch') {
+        const currentUrl = location.href;
+        const reloadFlag = sessionStorage.getItem('bt_reload_check');
+
+        // If the current URL is NOT the one we just reloaded for
+        if (reloadFlag !== currentUrl) {
+            // Set the flag FIRST
+            sessionStorage.setItem('bt_reload_check', currentUrl);
+         
+            // Perform the reload
+            location.reload();
+        }
+    } else {
+        // Clear the flag if they go back to Home or Search 
+        // so clicking the same video later triggers a fresh check
+        sessionStorage.removeItem('bt_reload_check');
+    }
+  });
 }());

--- a/src/scripts/seed.js
+++ b/src/scripts/seed.js
@@ -266,23 +266,24 @@
 
   // "Fix" which forcefully reloads the page when going to a watch video
   // Needed because not all information is available when you click on a video on the home page
+  // Because of youtube doing some quick loading magic from home page/ search page. 
   window.addEventListener('yt-navigate-finish', function(event) {
     if (location.pathname === '/watch') {
-        const currentUrl = location.href;
-        const reloadFlag = sessionStorage.getItem('bt_reload_check');
+      const currentUrl = location.href;
+      const reloadFlag = sessionStorage.getItem('bt_reload_check');
 
-        // If the current URL is NOT the one we just reloaded for
-        if (reloadFlag !== currentUrl) {
-            // Set the flag FIRST
-            sessionStorage.setItem('bt_reload_check', currentUrl);
-         
-            // Perform the reload
-            location.reload();
-        }
+      // If the current URL is NOT the one we just reloaded for
+      if (reloadFlag !== currentUrl) {
+        // Set the flag FIRST
+        sessionStorage.setItem('bt_reload_check', currentUrl);
+       
+        // Perform the reload
+        location.reload();
+      }
     } else {
-        // Clear the flag if they go back to Home or Search 
-        // so clicking the same video later triggers a fresh check
-        sessionStorage.removeItem('bt_reload_check');
+      // Clear the flag if you go back to Home or Search 
+      // so clicking the same video later triggers a fresh reload
+      sessionStorage.removeItem('bt_reload_check');
     }
   });
 }());


### PR DESCRIPTION
It seems like YouTube has some quick-loading magic when clicking a video from the homepage/ search page.
When this is triggered, it won't have the correct data from blocking the videos on the right-hand side. 

There is probably a good way to deal with this. But I am just force reloading the page to fix this.