### PR TITLE
Fix Block Channel button triggering YouTube share

### DIFF
--- a/src/scripts/inject.js
+++ b/src/scripts/inject.js
@@ -1567,13 +1567,20 @@
   }
 
   function createCleanContext(items, storageData, isChannel, currentObj) {
-    let item;
-    if (items.length === 8)
-      item = isChannel ? items[6] : items[5];
-    else
-      item = isChannel ? items[5] : items[4];
-    if (storageData.options.block_feedback && item) {
+    if (storageData.options.block_feedback && items.length > 0) {
+      // Search by imageName: homepage has REMOVE/NOT_INTERESTED, history page has DELETE
+      const targetIcons = isChannel ? ['REMOVE', 'DELETE'] : ['NOT_INTERESTED', 'DELETE'];
+      let item;
+      for (const icon of targetIcons) {
+        item = items.find(i => {
+          const imageName = getObjectByPath(i, 'listItemViewModel.leadingImage.sources.clientResource.imageName');
+          return imageName === icon;
+        });
+        if (item) break;
+      }
+      if (item) {
         return item?.listItemViewModel?.rendererContext;
+      }
     }
 
     const baseContext = items[0]?.listItemViewModel?.rendererContext;


### PR DESCRIPTION
createCleanContext used hardcoded array indices to select the YouTube action button to clone for block_feedback. YouTube menus vary by page:

  Homepage (8 items): NOT_INTERESTED=[5], REMOVE=[6]
  History  (6 items): SHARE=[4], DELETE=[5]

On the history page, video block picked items[4]=Share instead of DELETE, triggering the Share dialog. Channel block happened to pick items[5]=DELETE correctly.

Replace index lookup with imageName search:
  Channel: REMOVE (homepage) → fallback DELETE (history)
  Video:   NOT_INTERESTED (homepage) → fallback DELETE (history)

https://claude.ai/code/session_014TpmSc7H7o9f7SX3Wvy1FM