### PR TITLE
Add keyboard shortcut for saving options

### DIFF
--- a/src/ui/options.js
+++ b/src/ui/options.js
@@ -340,6 +340,13 @@
     $('save_btn').classList.remove('disabled-btn');
   });
 
+  window.addEventListener('keydown', (event) => {
+    if ((event.ctrlKey || event.metaKey) && event.key === 's') { // Ctrl + S
+      event.preventDefault();
+      saveForm();
+    }
+  }, true);
+
   function initTabs(name) {
     const element = document.getElementById(name);
     element.querySelectorAll("input[type='radio']").forEach((box) => {


### PR DESCRIPTION
I often press `Ctrl+S` trying to save changes in the options page, especially when editing code in `Advanced Blocking`. But I'd only get the popup to save the html of the options page, which clearly no one needs.

This PR adds the ability to save options with `Ctrl+S` shortcut. Very convenient when editing and testing `Advanced Blocking` rules.