### PR TITLE
Hide search results from blocked YouTube collaborator channels

### DIFF
--- a/src/scripts/inject.js
+++ b/src/scripts/inject.js
@@ -158,13 +158,39 @@
 
   // TODO: add rules descriptions
   // !! Filter Rules definitions
+  const bylinePaths = [
+    'shortBylineText',
+    'longBylineText',
+    'ownerText',
+    'bylineText',
+  ];
+  const collaboratorDialogPath = 'runs.navigationEndpoint.showDialogCommand.panelLoadingStrategy.inlineContent.dialogViewModel.customContent.listViewModel.listItems.listItemViewModel';
+  const collaboratorChannelIdPaths = bylinePaths.map((path) =>
+    `${path}.${collaboratorDialogPath}.rendererContext.commandContext.onTap.innertubeCommand.browseEndpoint.browseId`);
+  const collaboratorChannelNamePaths = bylinePaths.map((path) =>
+    `${path}.${collaboratorDialogPath}.title.content`);
+  const avatarCollaboratorPath = 'avatar.avatarStackViewModel.rendererContext.commandContext.onTap.innertubeCommand.showDialogCommand.panelLoadingStrategy.inlineContent.dialogViewModel.customContent.listViewModel.listItems.listItemViewModel';
+
   const baseRules = {
     videoId: 'videoId',
-    channelId: 'shortBylineText.runs.navigationEndpoint.browseEndpoint.browseId',
+    channelId: [
+      'shortBylineText.runs.navigationEndpoint.browseEndpoint.browseId',
+      'longBylineText.runs.navigationEndpoint.browseEndpoint.browseId',
+      'ownerText.runs.navigationEndpoint.browseEndpoint.browseId',
+      'bylineText.runs.navigationEndpoint.browseEndpoint.browseId',
+      'channelThumbnailSupportedRenderers.channelThumbnailWithLinkRenderer.navigationEndpoint.browseEndpoint.browseId',
+      'avatar.avatarStackViewModel.rendererContext.commandContext.onTap.innertubeCommand.browseEndpoint.browseId',
+      `${avatarCollaboratorPath}.rendererContext.commandContext.onTap.innertubeCommand.browseEndpoint.browseId`,
+      ...collaboratorChannelIdPaths,
+    ],
     channelBadges: 'ownerBadges',
     channelName: [
       'shortBylineText',
       'longBylineText',
+      'ownerText',
+      'bylineText',
+      `${avatarCollaboratorPath}.title.content`,
+      ...collaboratorChannelNamePaths,
     ],
     title: ['title'],
     vidLength: ['thumbnailOverlays.thumbnailOverlayTimeStatusRenderer.text'],
@@ -516,14 +542,20 @@
       const properties = storageData.filterData[h];
       if (regexProps.includes(h) && (properties === undefined || properties.length === 0 && !jsFilterEnabled)) return false;
 
-      let value = getFlattenByPath(obj, filterPath);
+      const isRegexFilter = regexProps.includes(h);
+      const shouldMatchAllValues = ['channelId', 'channelName'].includes(h);
+      const values = shouldMatchAllValues ? getFlattenByPathAll(obj, filterPath) : [];
+      let value = shouldMatchAllValues ? values[0] : getFlattenByPath(obj, filterPath);
       if (value === undefined) return false;
 
       if (h === 'percentWatched' && storageData.options.percent_watched_hide && objectType != 'playlistPanelVideoRenderer'
            && !['/feed/history', '/feed/library', '/playlist'].includes(document.location.pathname)
            && parseInt(value) >= storageData.options.percent_watched_hide) return true;
 
-      if (regexProps.includes(h) && properties.some(prop => prop && prop.test(value))) return true;
+      if (
+        isRegexFilter &&
+        matchRegexValues(properties, shouldMatchAllValues ? values : [value])
+      ) return true;
 
       if (h === 'vidLength') {
         const vidLen = parseTime(value);
@@ -938,6 +970,67 @@
       value = getObjectByPath(obj, filterPathArr[idx]);
       if (value !== undefined) return flattenRuns(value);
     }
+  }
+
+  function getFlattenByPathAll(obj, filterPath) {
+    if (filterPath === undefined) return [];
+    const filterPathArr = Array.isArray(filterPath) ? filterPath : [filterPath];
+    return filterPathArr.reduce((res, path) => {
+      getObjectsByPath(obj, path).forEach((value) => {
+        if (value !== undefined) res.push(flattenRuns(value));
+      });
+      return res;
+    }, []);
+  }
+
+  function matchRegexValues(properties, values) {
+    if (!Array.isArray(properties)) return false;
+    return properties.some((prop) => {
+      if (!prop) return false;
+      return values.some((value) => {
+        prop.lastIndex = 0;
+        return prop.test(value);
+      });
+    });
+  }
+
+  function getObjectsByPath(obj, path) {
+    const paths = Array.isArray(path) ? path : path.split('.');
+    return paths.reduce((values, v) => {
+      return values.reduce((res, value) => res.concat(getPathSegmentValues(value, v)), []);
+    }, [obj]);
+  }
+
+  function getPathSegmentValues(obj, path) {
+    if (obj === undefined || obj === null) return [];
+
+    if (/\[.*\]/.test(path)) {
+      const baseMatch = path.match(/^([^\[]+)/);
+      const base = baseMatch && baseMatch[1];
+      const idxMatches = [...path.matchAll(/\[(\d+)\]/g)].map(m => parseInt(m[1], 10));
+      let values = base ? getPathPropertyValues(obj, base) : [obj];
+
+      idxMatches.forEach((idx) => {
+        values = values.reduce((res, value) => {
+          if (Array.isArray(value) && idx >= 0 && idx < value.length) {
+            res.push(value[idx]);
+          }
+          return res;
+        }, []);
+      });
+
+      return values;
+    }
+
+    return getPathPropertyValues(obj, path);
+  }
+
+  function getPathPropertyValues(obj, prop) {
+    const values = Array.isArray(obj) ? obj : [obj];
+    return values.reduce((res, value) => {
+      if (value && has.call(value, prop)) res.push(value[prop]);
+      return res;
+    }, []);
   }
 
   function postMessage(type, data) {


### PR DESCRIPTION
### Summary

Fixes filtering for YouTube search results that use YouTube Collaborations.

When a video has multiple collaborators, blocking one collaborator channel can block the video page itself, but the video could still remain visible in search results.

YouTube documents this feature as [Collaborations](https://support.google.com/youtube/answer/16554898).

### Technical details

Some search `videoRenderer` objects do not expose collaborator channels through the usual byline `browseEndpoint` path. Instead, collaborator channel IDs are stored under a `showDialogCommand` used for the Collaborators dialog.

This change:

- adds channel ID/name paths for collaborator dialog entries
- includes avatar-stack collaborator entries
- checks all extracted `channelId` / `channelName` values, not only the first one

### Verification

Tested with a search result where the rendered byline shows multiple collaborator channels.

Before:
- a video from a blocked collaborator channel could still appear in search results
<img width="1486" height="1005" alt="2026_06_27_13_19" src="https://github.com/user-attachments/assets/55fab7c9-88e6-4a9f-9fd7-601ce071a95b" />

After:
- the search result is hidden when any collaborator channel matches the block list
<img width="1561" height="984" alt="2026_06_27_13_20" src="https://github.com/user-attachments/assets/137d6c9b-3f9c-4fa2-ac94-96040ef888fe" />

The screenshots use a real search result because finding a neutral, reproducible YouTube Collaboration example was difficult.