### PR TITLE
Support YouTube no-cookie embeds

### DIFF
--- a/platform/chrome/manifest.json
+++ b/platform/chrome/manifest.json
@@ -5,20 +5,20 @@
   "manifest_version": 3,
   "content_scripts": [
     {
-      "matches": ["https://www.youtube.com/*", "https://m.youtube.com/*"],
+      "matches": ["https://www.youtube.com/*", "https://m.youtube.com/*", "https://www.youtube-nocookie.com/*"],
       "js": ["src/scripts/content_script.js"],
       "run_at": "document_start",
       "all_frames": true
     },
     {
-      "matches": ["https://www.youtube.com/*", "https://m.youtube.com/*"],
+      "matches": ["https://www.youtube.com/*", "https://m.youtube.com/*", "https://www.youtube-nocookie.com/*"],
       "js": ["src/scripts/seed.js"],
       "run_at": "document_start",
       "all_frames": true,
       "world": "MAIN"
     },
     {
-      "matches": ["https://www.youtube.com/*", "https://m.youtube.com/*"],
+      "matches": ["https://www.youtube.com/*", "https://m.youtube.com/*", "https://www.youtube-nocookie.com/*"],
       "js": ["src/scripts/inject.js"],
       "run_at": "document_start",
       "all_frames": true,

--- a/platform/firefox/manifest.json
+++ b/platform/firefox/manifest.json
@@ -5,20 +5,20 @@
   "manifest_version": 3,
   "content_scripts": [
     {
-      "matches": ["https://www.youtube.com/*", "https://m.youtube.com/*"],
+      "matches": ["https://www.youtube.com/*", "https://m.youtube.com/*", "https://www.youtube-nocookie.com/*"],
       "js": ["src/scripts/content_script.js"],
       "run_at": "document_start",
       "all_frames": true
     },
     {
-      "matches": ["https://www.youtube.com/*", "https://m.youtube.com/*"],
+      "matches": ["https://www.youtube.com/*", "https://m.youtube.com/*", "https://www.youtube-nocookie.com/*"],
       "js": ["src/scripts/seed.js"],
       "run_at": "document_start",
       "all_frames": true,
       "world": "MAIN"
     },
     {
-      "matches": ["https://www.youtube.com/*", "https://m.youtube.com/*"],
+      "matches": ["https://www.youtube.com/*", "https://m.youtube.com/*", "https://www.youtube-nocookie.com/*"],
       "js": ["src/scripts/inject.js"],
       "run_at": "document_start",
       "all_frames": true,

--- a/platform/firefox_selfhosted/manifest.json
+++ b/platform/firefox_selfhosted/manifest.json
@@ -5,20 +5,20 @@
   "manifest_version": 3,
   "content_scripts": [
     {
-      "matches": ["https://www.youtube.com/*", "https://m.youtube.com/*"],
+      "matches": ["https://www.youtube.com/*", "https://m.youtube.com/*", "https://www.youtube-nocookie.com/*"],
       "js": ["src/scripts/content_script.js"],
       "run_at": "document_start",
       "all_frames": true
     },
     {
-      "matches": ["https://www.youtube.com/*", "https://m.youtube.com/*"],
+      "matches": ["https://www.youtube.com/*", "https://m.youtube.com/*", "https://www.youtube-nocookie.com/*"],
       "js": ["src/scripts/seed.js"],
       "run_at": "document_start",
       "all_frames": true,
       "world": "MAIN"
     },
     {
-      "matches": ["https://www.youtube.com/*", "https://m.youtube.com/*"],
+      "matches": ["https://www.youtube.com/*", "https://m.youtube.com/*", "https://www.youtube-nocookie.com/*"],
       "js": ["src/scripts/inject.js"],
       "run_at": "document_start",
       "all_frames": true,

--- a/src/scripts/seed.js
+++ b/src/scripts/seed.js
@@ -127,6 +127,15 @@
     }
   }
 
+  function getPropertyDescriptor(obj, prop) {
+    while (obj) {
+      const descriptor = Object.getOwnPropertyDescriptor(obj, prop);
+      if (descriptor) return descriptor;
+      obj = Object.getPrototypeOf(obj);
+    }
+    return undefined;
+  }
+
   // Start
   if (window.writeEmbed || window.ytplayer || window.Polymer) {
     console.error('We may have lost the battle, but not the war');
@@ -158,18 +167,26 @@
   }
 
   if (window.location.pathname.startsWith('/embed/')) {
-    const XMLHttpRequestResponse = Object.getOwnPropertyDescriptor(XMLHttpRequest.prototype, 'response');
-    Object.defineProperty(XMLHttpRequest.prototype, 'response', {
-      get: function() {
-        if(!fetch_uris.some(u => this.responseURL.includes(u))) {
-          return XMLHttpRequestResponse.get.call(this);
-        }
-        let res = JSON.parse(XMLHttpRequestResponse.get.call(this).replace(')]}\'', ''));
-        window.btExports.fetchFilter(new URL(this.responseURL), res);
-        return JSON.stringify(res);
-      },
-      configurable: true
-    });
+    const XMLHttpRequestResponse = getPropertyDescriptor(XMLHttpRequest.prototype, 'response');
+    if (XMLHttpRequestResponse && XMLHttpRequestResponse.get) {
+      Object.defineProperty(XMLHttpRequest.prototype, 'response', {
+        get: function() {
+          const response = XMLHttpRequestResponse.get.call(this);
+          if(!this.responseURL || !fetch_uris.some(u => this.responseURL.includes(u))) {
+            return response;
+          }
+          if (typeof response !== 'string') return response;
+          try {
+            let res = JSON.parse(response.replace(')]}\'', ''));
+            window.btExports.fetchFilter(new URL(this.responseURL), res);
+            return JSON.stringify(res);
+          } catch (e) {
+            return response;
+          }
+        },
+        configurable: true
+      });
+    }
   }
 
   // Polymer elements modifications


### PR DESCRIPTION
### Summary

Adds support for YouTube privacy-enhanced embeds served from `www.youtube-nocookie.com`.

BlockTube already has embed-player filtering logic, but the content scripts were only matched on `www.youtube.com` and `m.youtube.com`. As a result, embedded players using the privacy-enhanced YouTube domain could bypass the existing filtering.

### Technical details

This change adds `https://www.youtube-nocookie.com/*` to the content script matches for Chrome, Firefox, and Firefox self-hosted manifests.

The scope stays limited to YouTube-owned embed domains. It does not add broader permissions such as `<all_urls>` or third-party host matches.

### Verification

Tested with an embedded player loaded through DuckDuckGo, where the page iframe pointed to:

```text
https://www.youtube-nocookie.com/embed/sppNnsF0gUk?wmode=transparent&iv_load_policy=3&autoplay=1&html5=1&showinfo=0&rel=0&modestbranding=1&playsinline=0&theme=light
```

<details>
<summary>Example DuckDuckGo embed</summary>

<img width="1919" height="996" alt="2026_06_28_15_51" src="https://github.com/user-attachments/assets/ef41f742-b9d4-4447-9fb8-bf54f848c295" />

</details>
